### PR TITLE
Update local/README.md for discourse setup

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -74,8 +74,8 @@ The following describes how to setup Discourse locally:
 
 ```shell
 # Boot docker container, use 3002 port, you can change to suit your environment
-docker pull discourse/discourse_dev:release
-docker run -d -p 1080:1080 -p 3002:3002 --hostname=discourse --name=discourse_dev discourse/discourse_dev:release /sbin/boot
+docker pull discourse/discourse_dev:1.4.0
+docker run -d -p 1080:1080 -p 3002:3002 --hostname=discourse --name=discourse_dev discourse/discourse_dev:1.4.0 /sbin/boot
 
 # Checkout Discourse source, stable branch
 git clone https://github.com/discourse/discourse.git


### PR DESCRIPTION
I was doing one challenge, but when I prepared development environment, I saw the following error

```
./bin/docker/rake db:migrate

== Seed from /src/db/fixtures/001_categories.rb

== Seed from /src/db/fixtures/002_groups.rb
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column "visible" of relation "groups" does not exist
LINE 1: UPDATE "groups" SET "visible" = 'f' WHERE "groups"."name" = ...
                            ^
: UPDATE "groups" SET "visible" = 'f' WHERE "groups"."name" = 'everyone'
(eval):5:in `block (2 levels) in run_file'
/src/lib/tasks/db.rake:8:in `block in <main>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
PG::UndefinedColumn: ERROR:  column "visible" of relation "groups" does not exist
LINE 1: UPDATE "groups" SET "visible" = 'f' WHERE "groups"."name" = ...
                            ^
(eval):5:in `block (2 levels) in run_file'
/src/lib/tasks/db.rake:8:in `block in <main>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```


This is because docker image discourse/discourse_dev:release was updated recently
https://hub.docker.com/r/discourse/discourse_dev/tags/

Following our readme file, it shows this error.


By using an old tag 1.4.0, problem is solved.


Mac 10.13.1 and Docker Version 17.09.0-ce-mac35 (19611)
