### PR TITLE
Github issue#22, Reduce number of calls

### DIFF
--- a/app/routes/topics/list.js
+++ b/app/routes/topics/list.js
@@ -53,7 +53,6 @@ module.exports = db =>
       return next(new errors.HttpStatusError(400, 'Please provide reference and referenceId filter parameters'));
     }
 
-    let isReadOnlyForAdmins = false;
     // Get topics from the Postgres database
     db.topics.findAll({ where: filter })
     .then((dbTopics) => {
@@ -64,44 +63,54 @@ module.exports = db =>
 
       logger.info(`${dbTopics.length} topics exist in pg, fetching from discourse`);
       let userId = req.authUser.userId.toString();
-      // check if user is admin or manager - they can view topics without being a part of the team
-      if (helper.isAdmin(req)) {
-        userId = config.get('discourseSystemUsername');
-      }
-      const topicPromises = dbTopics.map(dbTopic => retrieveTopic(logger, dbTopic, userId, discourseClient));
-
-      return Promise.all(topicPromises)
-      .then((topicResponses) => {
-        // filter null topics and sort in the  order of the last activity date descending (more recent activity first)
-        let topics = _.map(topicResponses, 'topic');
-        logger.info(`${dbTopics.length} topics fetched from discourse`);
-        if (topics.length === 0) {
-          throw new errors.HttpStatusError(404, 'Topic does not exist');
+      return helper.userHasAccessToEntity(req.authToken, req.id, filter.reference, filter.referenceId)
+      .then((hasAccessResp) => {
+        logger.info('Checking if user has access to identity');
+        const hasAccess = hasAccessResp[0];
+        if (!hasAccess && !helper.isAdmin(req)) {
+          throw new errors.HttpStatusError(403, 'User doesn\'t have access to the entity');
         }
-        isReadOnlyForAdmins = _.every(_.map(topicResponses, 'isReadOnlyForAdmins'));
-        // console.log(topics);
-        topics = _.chain(topics)
-          .filter(topic => topic != null)
-          .orderBy(['last_posted_at'], ['desc'])
-          .value();
 
-        logger.info(`${topics.length} topics after filter`);
-        if (!isReadOnlyForAdmins) {
-          // Mark all unread topics as read.
-          Promise.all(topics.filter(topic => !topic.read).map((topic) => {
-            if (topic.post_stream && topic.post_stream.posts && topic.post_stream.posts.length > 0) {
-              const postIds = topic.post_stream.posts.map(post => post.post_number);
-              return discourseClient.markTopicPostsRead(req.authUser.userId.toString(), topic.id, postIds);
-            }
-            return Promise.resolve();
-          })).catch((error) => {
-            logger.error('error marking topic posts read', error);
-          });
+        // if user does not have access but if user is admin or manager, use discourse system user to make API calls
+        // - they can view topics without being a part of the team
+        const usingAdminAccess = !hasAccess && helper.isAdmin(req);
+        if (usingAdminAccess) {
+          userId = config.get('discourseSystemUsername');
         }
-        logger.debug('adapting topics');
-        return adapter.adaptTopics({ topics, dbTopics });
-      })
-      .then(result => resp.status(200).send(util.wrapResponse(req.id, result)));
+        const topicPromises = dbTopics.map(dbTopic => retrieveTopic(logger, dbTopic, userId, discourseClient));
+
+        return Promise.all(topicPromises)
+        .then((topicResponses) => {
+          // filter null topics and sort in the  order of the last activity date descending (more recent activity first)
+          let topics = _.map(topicResponses, 'topic');
+          logger.info(`${dbTopics.length} topics fetched from discourse`);
+          if (topics.length === 0) {
+            throw new errors.HttpStatusError(404, 'Topic does not exist');
+          }
+
+          topics = _.chain(topics)
+            .filter(topic => topic != null)
+            .orderBy(['last_posted_at'], ['desc'])
+            .value();
+
+          logger.info(`${topics.length} topics after filter`);
+          if (!usingAdminAccess) {
+            // Mark all unread topics as read.
+            Promise.all(topics.filter(topic => !topic.read).map((topic) => {
+              if (topic.post_stream && topic.post_stream.posts && topic.post_stream.posts.length > 0) {
+                const postIds = topic.post_stream.posts.map(post => post.post_number);
+                return discourseClient.markTopicPostsRead(req.authUser.userId.toString(), topic.id, postIds);
+              }
+              return Promise.resolve();
+            })).catch((error) => {
+              logger.error('error marking topic posts read', error);
+            });
+          }
+          logger.debug('adapting topics');
+          return adapter.adaptTopics({ topics, dbTopics });
+        })
+        .then(result => resp.status(200).send(util.wrapResponse(req.id, result)));
+      });
     }).catch((error) => {
       next(error);
     });

--- a/app/routes/topics/list.spec.js
+++ b/app/routes/topics/list.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions, newline-per-chained-call */
 
-import { clearDB, prepareDB, jwts } from '../../tests';
+import { clearDB, prepareDB, jwts, getDecodedToken } from '../../tests';
 
 require('should-sinon');
 
@@ -22,6 +22,13 @@ describe('GET /v4/topics ', () => {
   // const testQuery3 = {
   //   filter: 'tag=tag&reference=notexist&referenceId=referenceId',
   // };
+  const memberUser = {
+    handle: getDecodedToken(jwts.member).handle,
+    userId: getDecodedToken(jwts.member).userId,
+    firstName: 'fname',
+    lastName: 'lName',
+    email: 'some@abc.com',
+  };
   let sandbox;
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
@@ -133,8 +140,12 @@ describe('GET /v4/topics ', () => {
 
   it('should return topics even if user is not part of project team but is a manager', (done) => {
     const getStub = sandbox.stub(axios, 'get').resolves({ data: topicJson });
+    // resolves call (with 403) to reference endpoint in helper.userHasAccessToEntity
+    getStub.withArgs('http://reftest/referenceId').resolves({
+      data: { result: { status: 403 } },
+    });
     // mark read
-    // const postStub = sandbox.stub(axios, 'post').resolves({});
+    const postStub = sandbox.stub(axios, 'post').resolves({});
 
     request(server)
       .get(apiPath)
@@ -146,21 +157,56 @@ describe('GET /v4/topics ', () => {
           return done(err);
         }
         res.body.result.content.should.be.of.length(1);
-        sinon.assert.calledOnce(getStub);
-        // sinon.assert.notCalled(postStub);
+        // once for reference endpoint call  and once for getting the topics from discourse
+        sinon.assert.calledTwice(getStub);
+        // should not call post endpoint because it should not call discourse.markTopicPostsRead
+        // when using manager access
+        sinon.assert.notCalled(postStub);
+        return done();
+      });
+  });
+
+  it('should return topics even if user is not part of project team but is a manager (ref lookup error)', (done) => {
+    const getStub = sandbox.stub(axios, 'get').resolves({ data: topicJson });
+    // resolves call (with 403) to reference endpoint in helper.userHasAccessToEntity
+    getStub.withArgs('http://reftest/referenceId').rejects({
+      message: 'ERROR_IN_ACCESSING_REF_ENDPOINT',
+    });
+    // mark read
+    const postStub = sandbox.stub(axios, 'post').resolves({});
+
+    request(server)
+      .get(apiPath)
+      .set({ Authorization: `Bearer ${jwts.manager}` })
+      .query(testQuery)
+      .expect(200)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        res.body.result.content.should.be.of.length(1);
+        // once for reference endpoint call  and once for getting the topics from discourse
+        sinon.assert.calledTwice(getStub);
+        // should not call post endpoint because it should not call discourse.markTopicPostsRead
+        // when using manager access
+        sinon.assert.notCalled(postStub);
         return done();
       });
   });
 
   it('should return topics even if user is not part of project team but is a admin', (done) => {
     const getStub = sandbox.stub(axios, 'get').resolves({ data: topicJson });
+    // rejects to reference endpoint in helper.userHasAccessToEntity
+    getStub.withArgs('http://reftest/referenceId').resolves({
+      data: { result: { status: 403 } },
+    });
     // mark read
-    // const postStub = sandbox.stub(axios, 'post').resolves({});
+    const postStub = sandbox.stub(axios, 'post').resolves({});
 
     request(server)
       .get(apiPath)
       .set({
-        Authorization: `Bearer ${jwts.manager}`,
+        Authorization: `Bearer ${jwts.admin}`,
       })
       .query(testQuery)
       .expect(200)
@@ -169,8 +215,41 @@ describe('GET /v4/topics ', () => {
           return done(err);
         }
         res.body.result.content.should.be.of.length(1);
-        sinon.assert.calledOnce(getStub);
-        // sinon.assert.notCalled(postStub);
+        // once for reference endpoint call  and once for getting the topics from discourse
+        sinon.assert.calledTwice(getStub);
+        // should not call post endpoint because it should not call discourse.markTopicPostsRead
+        // when using admin access
+        sinon.assert.notCalled(postStub);
+        return done();
+      });
+  });
+
+  it('should return topics even if user is not part of project team but is a admin (Ref lookup error)', (done) => {
+    const getStub = sandbox.stub(axios, 'get').resolves({ data: topicJson });
+    // rejects to reference endpoint in helper.userHasAccessToEntity
+    getStub.withArgs('http://reftest/referenceId').rejects({
+      message: 'ERROR_IN_ACCESSING_REF_ENDPOINT',
+    });
+    // mark read
+    const postStub = sandbox.stub(axios, 'post').resolves({});
+
+    request(server)
+      .get(apiPath)
+      .set({
+        Authorization: `Bearer ${jwts.admin}`,
+      })
+      .query(testQuery)
+      .expect(200)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        res.body.result.content.should.be.of.length(1);
+        // once for reference endpoint call  and once for getting the topics from discourse
+        sinon.assert.calledTwice(getStub);
+        // should not call post endpoint because it should not call discourse.markTopicPostsRead
+        // when using admin access
+        sinon.assert.notCalled(postStub);
         return done();
       });
   });
@@ -178,9 +257,14 @@ describe('GET /v4/topics ', () => {
   // FIXME valid use case
   it('should return 200 response with matching topicLookup', (done) => {
     const getStub = sandbox.stub(axios, 'get').resolves({ data: topicJson });
-    // mark read
 
+    // resolves call (with 200) to reference endpoint in helper.userHasAccessToEntity
+    getStub.withArgs('http://reftest/referenceId').resolves({
+      data: { result: { status: 200, content: [{ userId: memberUser.userId }] } },
+    });
+    // mark read
     const postStub = sandbox.stub(axios, 'post').resolves({});
+
     request(server)
       .get(apiPath)
       .set({ Authorization: `Bearer ${jwts.member}` })
@@ -190,7 +274,9 @@ describe('GET /v4/topics ', () => {
         if (err) {
           return done(err);
         }
-        sinon.assert.calledOnce(getStub);
+        // once for reference endpoint call  and once for getting the topics from discourse
+        sinon.assert.calledTwice(getStub);
+        // should call post endpoint in discourse.markTopicPostsRead as it not using admin access
         sinon.assert.calledOnce(postStub);
         return done();
       });


### PR DESCRIPTION
— Found that after pre deciding the admin access, functionality marking topics as read topics is making unnecessary calls for admin access because now there was no flag to identify if it was admin access or not. I was making admin access call to discourse if the calling user has manager/admin role even though they might already be part of the team.

fyi @mtwomey @gondzo, please let me know if you find any thing wrong in it. I am merging it for now to test things on dev and get it released tomorrow with admin view milestone.