### PR TITLE
Feature/reduce number of calls

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -17,7 +17,7 @@ module.exports = {
   REFERENCE_LOOKUPS: {
     PROJECT: 'project',
   },
-  
+
   BUS_API_EVENT: {
     TOPIC_CREATED: 'connect.project.topic.created',
     TOPIC_DELETED: 'connect.project.topic.deleted',

--- a/app/constants.js
+++ b/app/constants.js
@@ -6,4 +6,8 @@ module.exports = {
     MANAGER: 'Connect Manager',
     COPILOT: 'Connect Copilot',
   },
+
+  REFERENCE_LOOKUPS: {
+    PROJECT: 'project',
+  },
 };

--- a/app/routes/topics/create.js
+++ b/app/routes/topics/create.js
@@ -9,6 +9,7 @@ const HelperService = require('../../services/helper');
 const errors = require('common-errors');
 const Joi = require('joi');
 const Adapter = require('../../services/adapter');
+const { REFERENCE_LOOKUPS } = require('../../constants');
 
 
 const DISCOURSE_SYSTEM_USERNAME = config.get('discourseSystemUsername');
@@ -50,7 +51,7 @@ module.exports = db =>
         logger.info('Checking if user has access to identity');
         const hasAccess = hasAccessResp[0];
         if (!hasAccess) { throw new errors.HttpStatusError(403, 'User doesn\'t have access to the entity'); }
-        if (params.reference.toLowerCase() === 'project') {
+        if (params.reference.toLowerCase() === REFERENCE_LOOKUPS.PROJECT) {
           const projectMembers = _.get(hasAccessResp[1], 'members', []);
             // get users list
           const topicUsers = _.map(projectMembers, member => member.userId.toString());

--- a/app/routes/topics/create.spec.js
+++ b/app/routes/topics/create.spec.js
@@ -20,7 +20,7 @@ const username = 'test1';
 describe('POST /v4/topics ', () => {
   const apiPath = '/v4/topics';
   const testBody = {
-    reference: 'reference',
+    reference: 'project',
     referenceId: '1',
     tag: 'tag',
     title: 'title',
@@ -180,7 +180,7 @@ describe('POST /v4/topics ', () => {
     const stub = sandbox.stub(axios, 'get');
     // resolves call to reference endpoint in helper.userHasAccessToEntity
     stub.withArgs('http://reftest/1').resolves({
-      data: { result: { status: 200, content: [{ userId: adminUser.userId }] } },
+      data: { result: { status: 200, content: { members: [{ userId: adminUser.userId }] } } },
     });
     // Rejects the discourse get user call
     stub.withArgs(`/users/${adminUser.userId}.json?api_username=${adminUser.userId}`)
@@ -229,7 +229,7 @@ describe('POST /v4/topics ', () => {
     const stub = sandbox.stub(axios, 'get');
     // resolves call to reference endpoint in helper.userHasAccessToEntity
     stub.withArgs('http://reftest/1').resolves({
-      data: { result: { status: 200, content: [{ userId: adminUser.userId }] } },
+      data: { result: { status: 200, content: { members: [{ userId: adminUser.userId }] } } },
     });
     // Rejects the discourse get user call
     stub.withArgs(`/users/${adminUser.userId}.json?api_username=${adminUser.userId}`)
@@ -278,7 +278,7 @@ describe('POST /v4/topics ', () => {
     const stub = sandbox.stub(axios, 'get');
     // resolves call to reference endpoint in helper.userHasAccessToEntity
     stub.withArgs('http://reftest/1').resolves({
-      data: { result: { status: 200, content: [{ userId: adminUser.userId }] } },
+      data: { result: { status: 200, content: { members: [{ userId: adminUser.userId }] } } },
     });
     // Rejects the discourse get user call
     stub.withArgs(`/users/${adminUser.userId}.json?api_username=${adminUser.userId}`)

--- a/app/tests/index.js
+++ b/app/tests/index.js
@@ -41,14 +41,14 @@ function prepareDB(done) {
       const promises = [
         models.topics.create({
           // id: 1,
-          reference: 'reference',
+          reference: 'project',
           referenceId: 'referenceId',
           discourseTopicId: 1,
           tag: 'tag',
         }),
         models.referenceLookups.create({
           id: 1,
-          reference: 'reference',
+          reference: 'project',
           endpoint: 'http://reftest/{id}', // eslint-disable-line
         }),
       ];


### PR DESCRIPTION
— Fixed issue surfaced after production deployment. It was not there on dev because when I checked on dev, we don’t had the project service updated in dev. However, on production we got project service deployed. The root cause is that for administrators (and connect admins) we don’t throw 403 or 404 when calling /projects/{id} endpoint and this endpoint is used to validate the access of the user and hence deciding which user to use when calling to discourse.
