### PR TITLE
Revert "adding notifications prefix in topic name to decouple it from event bus."

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -19,10 +19,10 @@ module.exports = {
   },
 
   BUS_API_EVENT: {
-    TOPIC_CREATED: 'notifications.connect.project.topic.created',
-    TOPIC_DELETED: 'notifications.connect.project.topic.deleted',
-    POST_CREATED: 'notifications.connect.project.post.created',
-    POST_UPDATED: 'notifications.connect.project.post.edited',
-    POST_DELETED: 'notifications.connect.project.post.deleted',
+    TOPIC_CREATED: 'connect.project.topic.created',
+    TOPIC_DELETED: 'connect.project.topic.deleted',
+    POST_CREATED: 'connect.project.post.created',
+    POST_UPDATED: 'connect.project.post.edited',
+    POST_DELETED: 'connect.project.post.deleted',
   },
 };


### PR DESCRIPTION
Reverts topcoder-platform/tc-message-service#40

fyi @sachin-maheshwari temporary reverting it for production release.