### PR TITLE
tc-email-service release 

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -19,10 +19,10 @@ module.exports = {
   },
 
   BUS_API_EVENT: {
-    TOPIC_CREATED: 'connect.project.topic.created',
-    TOPIC_DELETED: 'connect.project.topic.deleted',
-    POST_CREATED: 'connect.project.post.created',
-    POST_UPDATED: 'connect.project.post.edited',
-    POST_DELETED: 'connect.project.post.deleted',
+    TOPIC_CREATED: 'notifications.connect.project.topic.created',
+    TOPIC_DELETED: 'notifications.connect.project.topic.deleted',
+    POST_CREATED: 'notifications.connect.project.post.created',
+    POST_UPDATED: 'notifications.connect.project.post.edited',
+    POST_DELETED: 'notifications.connect.project.post.deleted',
   },
 };


### PR DESCRIPTION
Add "notification" prefix to decouple the dependency from tc-bus-api.  