### PR TITLE
Topic webhook

### DIFF
--- a/app/routes/discourse/webhook.js
+++ b/app/routes/discourse/webhook.js
@@ -157,7 +157,7 @@ const saveTopic = (db, req, resp, topic, formatMessage) => {
 
           // reprocess any failed posts that came in before the topic
           DynamoService.findByTopicIdAndType(topic.id, 'post').then((data) => {
-            if (data.Items) {
+            if (data && data.Items) {
               data.Items.map(post => post['Id']['S']).forEach((postId) => {
                 DynamoService.findPayloadById(postId).then((post) => {
                   process(db, req, resp, null, post);

--- a/app/routes/discourse/webhook.js
+++ b/app/routes/discourse/webhook.js
@@ -5,15 +5,26 @@ const { EVENT, DISCOURSE_WEBHOOK_STATUS } = require('../../constants');
 const Adapter = require('../../services/adapter');
 
 /*
-* Create standard log message for discource webhook.
+* Create standard log message for post discource webhook.
 *
 * @param {String} message
 * @param {Object} post
 * @param {Object} savedPost saved by this service
 * @returns {void}
 */
-const createLogMessage = (message, post, savedPost = {}) =>
-  `Discourse Webhook :: ${message}  -  {postId: ${post.id}, topicId: ${post.topic_id || post.topicId}, savedPostId: ${savedPost.id} }`
+const createPostLogMessage = (message, post, savedPost = {}) =>
+  `Discourse Webhook :: ${message}  -  { postId: ${post.id}, topicId: ${post.topic_id || post.topicId}, savedPostId: ${savedPost.id} }`
+
+/*
+* Create standard log message for topic discource webhook.
+*
+* @param {String} message
+* @param {Object} topic
+* @param {Object} savedTopic saved by this service
+* @returns {void}
+*/
+const createTopicLogMessage = (message, topic, savedTopic = {}) =>
+  `Discourse Webhook :: ${message}  -  { topicId: ${topic.id}, savedTopicId: ${savedTopic.id} }`
 
 /*
 * Sends 200 status. Sends back a success message to the webhook to indicate message received.
@@ -35,12 +46,13 @@ const success = (resp) =>
 *         usually indicates a failure to send and results in an exponential backoff
 *         webhook retry.
 *
-* @param {Object} req the request
 * @param {Object} db the database
+* @param {Object} req the request
 * @param {Object} post the raw post to save
+* @param {Function} formatMessage function to format the log message
 * @returns {Object} promise that will resolve when the post is saved
 */
-const savePost = (req, db, post) => {
+const savePost = (db, req, post, formatMessage) => {
   const logger = req.log;
   const adapter = new Adapter(logger, db);
   return new Promise((resolve, reject) => {
@@ -48,28 +60,112 @@ const savePost = (req, db, post) => {
       .then((topic) => { /* eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["topic"] }] */
         if (topic) {
           db.posts.createPost(db, post.cooked, topic, post.user_id).then((savedPost) => {
-            logger.debug(createLogMessage('Post created via discourse webhook.', post));
+            logger.debug(formatMessage('Post created via discourse webhook.', post));
             topic.highestPostNumber += 1;
-            topic.save().then(() => logger.debug(createLogMessage('Topic updated async for post.', post, savedPost)));
+            topic.save().then(() => logger.debug(formatMessage('Topic updated async for post.', post, savedPost)));
             db.post_user_stats.createStats(db, logger, {
               post: savedPost,
               userId: post.user_id,
               action: 'READ',
-            }).then(() => logger.debug(createLogMessage('post_user_stats entry created for post.', post, savedPost)));
+            }).then(() => logger.debug(formatMessage('post_user_stats entry created for post.', post, savedPost)));
             adapter.adaptPost(savedPost)
-              .then((post) => {
-                req.app.emit(EVENT.POST_CREATED, { post: savedPost, topic, req });
-                resolve(post);
+              .then((adaptedPost) => {
+                req.app.emit(EVENT.POST_CREATED, { post: adaptedPost, topic, req });
+                resolve(adaptedPost);
               }).catch((e) => {
-                reject(createLogMessage('Unable to adapt post for emit.', post));
+                reject(formatMessage('Unable to adapt post for emit.', post, savedPost));
               });
           });
         } else {
-          reject(createLogMessage('No topic found.', post));
+          reject(formatMessage('No topic found.', post));
         }
       }).catch((e) => {
-        reject(createLogMessage('Error while finding topic.', post));
+        reject(formatMessage('Error while finding topic.', post));
       });
+  });
+};
+
+/*
+* Saves the topic.
+*   TODO: Currently duplicates a lot of functionality from routes/topic/create.js
+*         In in the future, would want to combine these two in one place and remove
+*         the logic that is essentially in the controller/route handler. And based
+*         on the failure/success conditions have routes/topic/create.js return the
+*         correct HTTPStatus code.  This webhook is unconcerned with returning the
+*         correct HTTPStatus code as an error code (400 - 500) in most systems
+*         usually indicates a failure to send and results in an exponential backoff
+*         webhook retry.
+*
+* @param {Object} db the database
+* @param {Object} req the request
+* @param {Object} topic the raw topic to save
+* @param {Function} formatMessage function to format the log message
+* @returns {Object} promise that will resolve when the topic is saved
+*/
+const saveTopic = (db, req, topic, formatMessage) => {
+  const logger = req.log;
+  const adapter = new Adapter(logger, db);
+
+  // TODO: fix me, temporary
+  const params = {reference: 'reference', referenceId: 'referenceId'};
+  const pgTopic = {
+    reference: params.reference,
+    referenceId: params.referenceId,
+    title: topic.title,
+    tag: params.tag,
+  };
+
+  return new Promise((resolve, reject) => {
+    db.topics.createTopic(db, pgTopic, topic.user_id)
+      .then((savedTopic) => { /* eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["savedTopic"] }] */
+        req.app.emit(EVENT.TOPIC_CREATED, { topic: savedTopic, req });
+        logger.debug(formatMessage('Topic saved in Postgres.', topic, savedTopic));
+        resolve(adapter.adaptTopic({ dbTopic: savedTopic, totalPosts: 1 }));
+      }).catch((errorMessage) => {
+        reject(formatMessage('Error while saving topic.', topic));
+      });
+  });
+};
+
+/*
+* Process the topic or post from the discourse webhook.
+*
+* @param {Object} db the database
+* @param {Object} req the request
+* @param {Object} resp the response
+* @param {Object} topic the raw topic to save
+* @param {Object} post the raw post to save
+* @returns {Object} promise that will resolve when the topic is saved
+*/
+const process = (db, req, resp, topic, post) => {
+  const logger = req.log;
+
+  // objects
+  const obj = topic || post;
+  const type = topic ? 'topic' : 'post';
+
+  // ids
+  const id = `${type}_${obj.id}`;
+
+  // specific functions
+  const formatMessage = topic ? createTopicLogMessage : createPostLogMessage;
+  const save = topic ? saveTopic : savePost;
+
+  return DynamoService.save(id, obj).then((data) => {
+    logger.debug(formatMessage(`Initial loading of ${type} from discourse webhook successful.`, obj));
+    return save(db, req, obj, formatMessage).then((saved) => {
+      DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
+        logger.info(formatMessage(`Completed ${type} processing from discourse webhook.`, obj, saved));
+      }).catch((e) => {
+        logger.error(formatMessage(`Unable to mark ${type} from discourse webhook as completed.`, obj));
+      }).finally(() => success(resp));
+    }).catch((errorMessage) => {
+      logger.error(errorMessage);
+      return DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.ERROR).finally(() => success(resp));
+    });
+  }).catch((e) => {
+    logger.error(formatMessage(`Initial loading of ${type} from discourse webhook not successful.`, obj));
+    logger.error(e);
   });
 };
 
@@ -82,21 +178,12 @@ const savePost = (req, db, post) => {
 module.exports = db => (req, resp, next) => {
   const logger = req.log;
   const post = req.body.post;
-  const originalPostId = post.id;
-  return DynamoService.save(post).then((data) => {
-    logger.debug(createLogMessage('Initial loading of post from discourse webhook successful.', post));
-    return savePost(req, db, post).then((savedPost) => {
-      DynamoService.updateStatus(post.id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
-        logger.info(createLogMessage('Completed post processing from discourse webhook.', post, savedPost));
-      }).catch((e) => {
-        logger.error(createLogMessage('Unable to mark post from discourse webhook as completed.', post));
-      }).finally(() => success(resp));
-    }).catch((errorMessage) => {
-      logger.error(errorMessage);
-      return DynamoService.updateStatus(originalPostId, DISCOURSE_WEBHOOK_STATUS.ERROR).finally(() => success(resp));
-    });
-  }).catch((e) => {
-    logger.error(createLogMessage('Initial loading of post from discourse webhook not successful.', post));
-    logger.error(e);
-  });
+  const topic = req.body.topic;
+
+  if (topic || post) {
+    return process(db, req, resp, topic, post);
+  } else {
+    logger.warn('Unable to process discourse webhook', req);
+    return Promise.resolve();
+  }
 };

--- a/app/routes/discourse/webhook.js
+++ b/app/routes/discourse/webhook.js
@@ -48,18 +48,20 @@ const success = (resp) =>
 *
 * @param {Object} db the database
 * @param {Object} req the request
+* @param {Object} resp the response
 * @param {Object} post the raw post to save
 * @param {Function} formatMessage function to format the log message
 * @returns {Object} promise that will resolve when the post is saved
 */
-const savePost = (db, req, post, formatMessage) => {
+const savePost = (db, req, resp, post, formatMessage) => {
   const logger = req.log;
   const adapter = new Adapter(logger, db);
+  const userId = post.user_id;
   return new Promise((resolve, reject) => {
     db.topics.findById(post.topic_id)
       .then((topic) => { /* eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["topic"] }] */
         if (topic) {
-          db.posts.createPost(db, post.cooked, topic, post.user_id).then((savedPost) => {
+          db.posts.createPost(db, post.cooked, topic, userId).then((savedPost) => {
             logger.debug(formatMessage('Post created via discourse webhook.', post));
             topic.highestPostNumber += 1;
             topic.save().then(() => logger.debug(formatMessage('Topic updated async for post.', post, savedPost)));
@@ -70,9 +72,22 @@ const savePost = (db, req, post, formatMessage) => {
             }).then(() => logger.debug(formatMessage('post_user_stats entry created for post.', post, savedPost)));
             adapter.adaptPost(savedPost)
               .then((adaptedPost) => {
-                req.app.emit(EVENT.POST_CREATED, { post: adaptedPost, topic, req });
+                req.app.emit(EVENT.POST_CREATED, {
+                  post: {
+                    topicId: post.topic_id,
+                    id: post.id,
+                    postContent: post.raw
+                  },
+                  topic,
+                  req: {
+                    authUser: {
+                      userId
+                    }
+                  }
+                });
                 resolve(adaptedPost);
               }).catch((e) => {
+                logger.error(e);
                 reject(formatMessage('Unable to adapt post for emit.', post, savedPost));
               });
           });
@@ -98,30 +113,46 @@ const savePost = (db, req, post, formatMessage) => {
 *
 * @param {Object} db the database
 * @param {Object} req the request
+* @param {Object} resp the response
 * @param {Object} topic the raw topic to save
 * @param {Function} formatMessage function to format the log message
 * @returns {Object} promise that will resolve when the topic is saved
 */
-const saveTopic = (db, req, topic, formatMessage) => {
+const saveTopic = (db, req, resp, topic, formatMessage) => {
   const logger = req.log;
   const adapter = new Adapter(logger, db);
 
-  // TODO: fix me, temporary
-  const params = {reference: 'reference', referenceId: 'referenceId'};
+  const userId = topic.user_id;
   const pgTopic = {
-    reference: params.reference,
-    referenceId: params.referenceId,
+    reference: 'project',
+    referenceId: 'referenceId',
     title: topic.title,
-    tag: params.tag,
   };
 
   return new Promise((resolve, reject) => {
-    db.topics.createTopic(db, pgTopic, topic.user_id)
+    db.topics.createTopic(db, pgTopic, userId)
       .then((savedTopic) => { /* eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["savedTopic"] }] */
-        req.app.emit(EVENT.TOPIC_CREATED, { topic: savedTopic, req });
+        req.app.emit(EVENT.TOPIC_CREATED, { topic: pgTopic, req: { authUser: { userId } } });
         logger.debug(formatMessage('Topic saved in Postgres.', topic, savedTopic));
-        resolve(adapter.adaptTopic({ dbTopic: savedTopic, totalPosts: 1 }));
+        DynamoService.findByTopicIdAndType(topic.id, 'post').then((data) => {
+          if (data.Items) {
+            data.Items.map(post => post['Id']['S']).forEach((postId) => {
+              DynamoService.findById(postId).then((post) => {
+                process(db, req, resp, null, Object.assign({}, post, {topic_id: savedTopic.id}));
+              }).catch((e) => {
+                logger.warn(formatMesage('Unable to save post for topic', topic));
+                logger.warn(e);
+              })
+            });
+          }
+          resolve(savedTopic);
+        }).catch((error) => {
+          logger.error(formatMessage(error, topic));
+          logger.debug(formatMessage('Unable to fetch posts for new topic.', topic, savedTopic));
+          resolve(savedTopic);
+        });
       }).catch((errorMessage) => {
+        logger.error(formatMessage(errorMessage, topic));
         reject(formatMessage('Error while saving topic.', topic));
       });
   });
@@ -146,22 +177,29 @@ const process = (db, req, resp, topic, post) => {
 
   // ids
   const id = `${type}_${obj.id}`;
+  const topicId = topic ? topic.id : post.topic_id;
 
   // specific functions
   const formatMessage = topic ? createTopicLogMessage : createPostLogMessage;
   const save = topic ? saveTopic : savePost;
 
-  return DynamoService.save(id, obj).then((data) => {
+  return DynamoService.findOrCreate(id, topicId, type, obj).then((data) => {
     logger.debug(formatMessage(`Initial loading of ${type} from discourse webhook successful.`, obj));
-    return save(db, req, obj, formatMessage).then((saved) => {
-      DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
-        logger.info(formatMessage(`Completed ${type} processing from discourse webhook.`, obj, saved));
+    return save(db, req, resp, obj, formatMessage).then((saved) => {
+      return DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
+        return DynamoService.updateNewId(id, saved.id).then((data) => {
+          logger.info(formatMessage(`Completed ${type} processing from discourse webhook.`, obj, saved));
+        }).catch((e) => {
+          logger.error(formatMessage(`Unable to update ${type} from discourse webhook with new id.`, obj));
+          logger.error(e);
+        })
       }).catch((e) => {
         logger.error(formatMessage(`Unable to mark ${type} from discourse webhook as completed.`, obj));
-      }).finally(() => success(resp));
+        logger.error(e);
+      });
     }).catch((errorMessage) => {
       logger.error(errorMessage);
-      return DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.ERROR).finally(() => success(resp));
+      return DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.ERROR);
     });
   }).catch((e) => {
     logger.error(formatMessage(`Initial loading of ${type} from discourse webhook not successful.`, obj));
@@ -181,7 +219,7 @@ module.exports = db => (req, resp, next) => {
   const topic = req.body.topic;
 
   if (topic || post) {
-    return process(db, req, resp, topic, post);
+    return process(db, req, resp, topic, post).finally(() => success(resp));
   } else {
     logger.warn('Unable to process discourse webhook', req);
     return Promise.resolve();

--- a/app/routes/discourse/webhook.js
+++ b/app/routes/discourse/webhook.js
@@ -212,13 +212,8 @@ const process = (db, req, resp, topic, post) => {
   return DynamoService.findOrCreate(id, topicId, type, obj).then((data) => {
     logger.debug(formatMessage(`Initial loading of ${type} from discourse webhook successful.`, obj));
     return save(db, req, resp, obj, formatMessage).then((saved) => {
-      return DynamoService.updateStatus(id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
-        return DynamoService.updateNewId(id, saved.id).then((data) => {
-          logger.info(formatMessage(`Completed ${type} processing from discourse webhook.`, obj, saved));
-        }).catch((e) => {
-          logger.error(formatMessage(`Unable to update ${type} from discourse webhook with new id.`, obj));
-          logger.error(e);
-        })
+      return DynamoService.updateNewIdAndStatus(id, saved.id, DISCOURSE_WEBHOOK_STATUS.COMPLETED).then((data) => {
+        logger.info(formatMessage(`Completed ${type} processing from discourse webhook.`, obj, saved));
       }).catch((e) => {
         logger.error(formatMessage(`Unable to mark ${type} from discourse webhook as completed.`, obj));
         logger.error(e);

--- a/app/routes/discourse/webhook.s3.dynamodb.mock.js
+++ b/app/routes/discourse/webhook.s3.dynamodb.mock.js
@@ -1,0 +1,18 @@
+const events = require('events');
+const concat = require('concat-stream');
+
+module.exports = function getItem(opts) {
+  const eventEmitter = new events.EventEmitter();
+
+  eventEmitter.send = function send(cb) {
+    opts.Body.pipe(concat((body) => {
+      eventEmitter.emit('httpUploadProgress', { total: body.length });
+      cb(null, {
+        Location: 'mock-location',
+        ETag: 'mock-etag',
+      });
+    }));
+  };
+
+  return eventEmitter;
+};

--- a/app/routes/discourse/webhook.spec.js
+++ b/app/routes/discourse/webhook.spec.js
@@ -2,7 +2,6 @@ import { clearDB, prepareDB } from '../../tests';
 
 const aws = require('aws-sdk');
 const AWS = require('aws-sdk-mock');
-const proxyquire = require('proxyquire');
 const Promise = require('bluebird');
 const axios = require('axios');
 const config = require('config');

--- a/app/routes/discourse/webhook.spec.js
+++ b/app/routes/discourse/webhook.spec.js
@@ -1,0 +1,118 @@
+import { clearDB, prepareDB } from '../../tests';
+
+const db = require('../../models');
+const request = require('supertest');
+// const postJson = require('../../tests/post.json');
+const server = require('../../app');
+
+const axios = require('axios');
+const config = require('config');
+
+const sinon = require('sinon');
+const should = require('should');
+require('should-sinon');
+
+const topicJson = require('../../tests/discourseNewTopicWebhook.json');
+const postJson = require('../../tests/discourseNewPostWebhook.json');
+const existingTopicJson = require('../../tests/discourseReferenceLookup.json');
+
+const topicHash = 'sha256=d02971ffe4f66f63024f3b55ac1c6d765e663b0fdf8496bdaec0e70c5563efee';
+const postHash = 'sha256=52921b7fe74a31ea2c3805c9cddacb2e889a85182c636b6a56c8f86824989cdf';
+
+describe('POST /v4/webhooks/topics/discourse', () => {
+  const apiPath = `/${config.apiVersion}/webhooks/topics/discourse`;
+
+  let sandbox;
+  beforeEach((done) => {
+    sandbox = sinon.sandbox.create();
+    prepareDB(done);
+  });
+  afterEach((done) => {
+    sandbox.restore();
+    clearDB(done);
+  });
+
+  it('should return 403 response without a token header', (done) => {
+    request(server)
+      .post(apiPath)
+      .expect(403, done);
+  });
+
+  it('should return 403 response with invalid token header', (done) => {
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': 'Token wrong',
+        'x-discourse-event': 'topic_created',
+      })
+      .send(topicJson)
+      .expect(403, done);
+  });
+
+  it('should return 403 response with invalid token header and no payload', (done) => {
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': 'Token wrong',
+        'x-discourse-event': 'topic_created',
+      })
+      .expect(403, done);
+  });
+
+  it('should return 200 if validate topic payload and will ignore if do not care about webhook', (done) => {
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': topicHash,
+        'x-discourse-event': 'dont_care',
+      })
+      .send(topicJson)
+      .expect(200, done)
+  });
+
+  it('should return 200 and process topic', (done) => {
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': topicHash,
+        'x-discourse-event': 'topic_created',
+      })
+      .send(topicJson)
+      .expect(200, done)
+  });
+
+  it('should return 200 and process topic', (done) => {
+    const getStub = sandbox.stub(axios, 'get');
+    getStub.withArgs(`${config.get('topicServiceUrl')}/15`).resolves(existingTopicJson);
+
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': topicHash,
+        'x-discourse-event': 'topic_created',
+      })
+      .send(topicJson)
+      .expect(200)
+      .end((err, res) => {
+        getStub.should.have.be.calledOnce;
+        done();
+      });
+  });
+
+  it('should return 200 and process post', (done) => {
+    request(server)
+      .post(apiPath)
+      .set({
+        'x-discourse-event-signature': postHash,
+        'x-discourse-event': 'topic_created',
+      })
+      .send(postJson)
+      .expect(200, done)
+  });
+
+
+  // .then(response => {
+      //     should(response.body.token).be.exactly('foo@bar.com')
+      // })
+
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -51,24 +51,30 @@ module.exports = (logger, db) => {
 
   // discourse webhook with custom auth logic
   router.route(`/${apiVersion}/webhooks/topics/discourse`).post((req, res, next) => {
+    const markUnauthorized = (request, response, message) => {
+      logger.warn(message);
+      response.status(403).json(util.wrapErrorResponse(request.id, 403, 'Invalid token issuer.'));
+      response.send();
+    };
     const discourseToken = req.header('x-discourse-event-signature');
     const discourseEvent = req.header('x-discourse-event');
     const allowedEvents = (discourseEvent === 'post_created' || discourseEvent === 'topic_created');
+
     if (discourseToken) {
-      if (allowedEvents) {
-        const token = SecurityHelper.calculateHmac(req.rawBody, 'sha256=');
-        if (discourseToken === token) {
+      const token = SecurityHelper.calculateHmac(req.rawBody || '', 'sha256=');
+      if (discourseToken === token) {
+        if (allowedEvents) {
           discourseWebhookPostHandler(db)(req, res, next);
-          return;
+        } else {
+          logger.info(`Discourse Webhook Event Ignored: { event: ${discourseEvent} }`);
+          res.status(200).send();
         }
-        logger.warn(`Token mismatch: ${discourseToken} != ${token}`);
       } else {
-        logger.info(`Discourse Webhook Event Ignored: { event: ${discourseEvent} }`);
-        return;
+        markUnauthorized(req, res, 'Invalid token.');
       }
+    } else {
+      markUnauthorized(req, res, 'Missing token.');
     }
-    res.status(403).json(util.wrapErrorResponse(req.id, 403, 'Invalid token issuer.'));
-    res.send();
   });
 
   router.all(`/${apiVersion}/topics*`, (req, res, next) => {

--- a/app/routes/sendgrid/webhook.spec.js
+++ b/app/routes/sendgrid/webhook.spec.js
@@ -1,0 +1,149 @@
+import { clearDB, prepareDB, findLast } from '../../tests';
+
+// const Promise = require('bluebird');
+const jwt = require('jsonwebtoken');
+const config = require('config');
+const request = require('supertest');
+const axios = require('axios');
+const sinon = require('sinon');
+const should = require('should');
+const util = require('../../util');
+require('should-sinon');
+
+const models = require('../../models');
+const server = require('../../app');
+
+describe('POST /v4/webhooks/topics/sendgrid', () => {
+  const apiPath = `/${config.apiVersion}/webhooks/topics/sendgrid`;
+
+  let sandbox;
+
+  beforeEach((done) => {
+    sandbox = sinon.sandbox.create();
+    prepareDB(done);
+  });
+  afterEach((done) => {
+    sandbox.restore();
+    clearDB(done);
+  });
+
+  it('should be able to process status failure', (done) => {
+    models.emailLogs.count().then((initialCount) => {
+      const getHttpClientStub = sandbox.stub(util, 'getHttpClient');
+      getHttpClientStub.returns(axios);
+
+      const postStub = sandbox.stub(axios, 'post');
+      const getStub = sandbox.stub(axios, 'get');
+
+      const authUrl = `${config.get('identityServiceEndpoint')}authorizations/`;
+      const authStr = 'clientId=&secret=';
+      const getAuthOpts = {
+        timeout: 4000,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      };
+      postStub.withArgs(authUrl, authStr, getAuthOpts)
+              .resolves({
+                data: { result: { status: 200, content: { token: 'mock' } } },
+              });
+
+      const getUsersOpts = {
+        headers: {
+          Authorization: 'Bearer mock',
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        params: {
+          fields: 'handle,id,email',
+          filter: 'email=jon@gmail.com',
+        },
+      };
+      getStub.withArgs(`${config.get('identityServiceEndpoint')}users`, getUsersOpts).resolves({
+        data: { result: { status: 200, content: [{ id: 1 }] } },
+      });
+
+      request(server)
+        .post(apiPath)
+        .field('text', 'Hi everyone!')
+        .field('subject', 'Hi')
+        .field('cc', 'bob@gmail.com')
+        .field('envelope', '{"from": "jon@gmail.com", "to": ["000000001/token@gmail.com"]}')
+        .expect(200)
+        .end((err) => {
+          should.not.exist(err);
+          getHttpClientStub.calledOnce.should.be.true();
+          getStub.calledOnce.should.be.true();
+          postStub.calledOnce.should.be.true();
+          models.emailLogs.count().then((afterCount) => {
+            afterCount.should.be.eql(initialCount + 1);
+            findLast(models.emailLogs).then((emailLog) => {
+              emailLog.fromAddress.should.be.eql('jon@gmail.com');
+              emailLog.status.should.be.eql('fail');
+              done();
+            });
+          });
+        });
+    });
+  });
+
+  it('should be able to process status successfully', (done) => {
+    models.emailLogs.count().then((initialCount) => {
+      const getHttpClientStub = sandbox.stub(util, 'getHttpClient');
+      getHttpClientStub.returns(axios);
+
+      const postStub = sandbox.stub(axios, 'post');
+      const getStub = sandbox.stub(axios, 'get');
+
+      const authUrl = `${config.get('identityServiceEndpoint')}authorizations/`;
+      const authStr = 'clientId=&secret=';
+      const getAuthOpts = {
+        timeout: 4000,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      };
+      postStub.withArgs(authUrl, authStr, getAuthOpts)
+              .resolves({
+                data: { result: { status: 200, content: { token: 'mock' } } },
+              });
+
+      const getUsersOpts = {
+        headers: {
+          Authorization: 'Bearer mock',
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        params: {
+          fields: 'handle,id,email',
+          filter: 'email=jon@gmail.com',
+        },
+      };
+      getStub.withArgs(`${config.get('identityServiceEndpoint')}users`, getUsersOpts).resolves({
+        data: { result: { status: 200, content: [{ id: 1 }] } },
+      });
+
+      const jwtStub = sandbox.stub(jwt, 'sign');
+      jwtStub.returns('junk.junk.supersecret');
+
+      request(server)
+        .post(apiPath)
+        .field('text', 'Hi everyone!')
+        .field('subject', 'Hi')
+        .field('cc', 'bob@gmail.com')
+        .field('envelope', '{"from": "jon@gmail.com", "to": ["000000001/supersecret@gmail.com"]}')
+        .expect(200)
+        .end((err) => {
+          should.not.exist(err);
+          getHttpClientStub.calledOnce.should.be.true();
+          getStub.calledOnce.should.be.true();
+          postStub.calledOnce.should.be.true();
+          jwtStub.calledOnce.should.be.true();
+          models.emailLogs.count().then((afterCount) => {
+            afterCount.should.be.eql(initialCount + 1);
+            findLast(models.emailLogs).then((emailLog) => {
+              emailLog.fromAddress.should.be.eql('jon@gmail.com');
+              emailLog.status.should.be.eql('success');
+              done();
+            });
+          });
+        });
+    });
+  });
+});

--- a/app/services/dynamodb.js
+++ b/app/services/dynamodb.js
@@ -7,20 +7,27 @@ const dynamodb = new aws.DynamoDB(config.get('aws.config'));
 const dynamodbTablename = config.get('aws.dynamodb.discourseWebhookLogsTable');
 const putItem = Promise.promisify(dynamodb.putItem.bind(dynamodb));
 const updateItem = Promise.promisify(dynamodb.updateItem.bind(dynamodb));
+const query = Promise.promisify(dynamodb.query.bind(dynamodb));
+const getItem = Promise.promisify(dynamodb.getItem.bind(dynamodb));
 
 /**
  * Save record in the dynamoddb.
  *
  * @param {String} id unique id to identify this object
+ * @param {Number} topicId topic id associated with this object
+ * @param {String} type type of object this is
  * @param {Object} payload object to save in the dynamodb
  * @returns {Object} promise from save
  */
-const save = (id, payload) =>
+const save = (id, topicId, type, payload) =>
   putItem({
     Item: {
       Id: { S: id.toString() },
+      TopicId: { S: topicId.toString() },
+      Type: { S: type },
       Payload: { S: JSON.stringify(payload) },
       Status: { S: DISCOURSE_WEBHOOK_STATUS.PENDING },
+      NewId: { S: ' ' },
     },
     ReturnConsumedCapacity: 'TOTAL',
     TableName: dynamodbTablename,
@@ -46,7 +53,114 @@ const updateStatus = (id, status) => {
   return updateItem(payload);
 };
 
+/**
+ * Update status of the entry in dynamodb.
+ *
+ * @param {String} id used to find records in dynamodb
+ * @param {String} newId new id stored in postgres
+ * @returns {Object} promise from the update
+ */
+const updateNewId = (id, newId) => {
+  const payload = {
+    ExpressionAttributeNames: { '#S': 'NewId' },
+    ExpressionAttributeValues: { ':s': { S: newId.toString() } },
+    Key: { Id: { S: id.toString() } },
+    ReturnValues: 'ALL_NEW',
+    TableName: dynamodbTablename,
+    UpdateExpression: 'SET #S = :s',
+  };
+
+  return updateItem(payload);
+};
+
+/**
+ * Find elements in dynamodb by topic id and type.
+ *
+ * @param {Number} topicId topic id used to find the elements
+ * @param {String} type object type to find
+ * @returns {Object} promise from the find
+ */
+const findByTopicIdAndType = (topicId, type) => {
+  const payload = {
+    IndexName: 'TopicId-Type-index',
+    ConsistentRead: false,
+    KeyConditionExpression: '#topicId = :topicId AND #type = :type',
+    ExpressionAttributeNames: {
+      '#topicId': 'TopicId',
+      '#type': 'Type',
+    },
+    ExpressionAttributeValues: {
+      ':topicId': { S: topicId.toString() },
+      ':type': { S: type },
+    },
+    TableName: dynamodbTablename,
+  };
+
+  return query(payload);
+};
+
+/**
+ * Find elements in dynamodb by id.
+ *
+ * @param {Number} id to find the element
+ * @returns {Object} promise from the find
+ */
+const findById = (id) => {
+  const payload = {
+    Key: {
+      Id: {
+        S: id.toString(),
+      },
+    },
+    TableName: dynamodbTablename,
+  };
+
+  return new Promise((resolve) => {
+    getItem(payload).then((item) => {
+      if (item.Item) {
+        try {
+          const existing = JSON.parse(item.Item.Payload.S);
+          resolve(existing);
+        } catch (e) {
+          resolve(null);
+        }
+      }
+      resolve(null);
+    }).catch(() => {
+      resolve(null);
+    });
+  });
+};
+
+/**
+ * Find or create the new element
+ *
+ * @param {String} id dynamodb id
+ * @param {Number} topicId used to mark this
+ * @param {String} type type of object this is
+ * @param {Object} payload to store
+ * @returns {Object} promise from the find
+ */
+const findOrCreate = (id, topicId, type, payload) =>
+  new Promise((resolve, reject) => {
+    findById(id).then((item) => {
+      if (item) {
+        resolve(item);
+      } else {
+        save(id, topicId, type, payload)
+          .then(saved => resolve(saved))
+          .catch(e => reject(e));
+      }
+    }).catch((e) => {
+      reject(e);
+    });
+  });
+
 module.exports = {
   save,
   updateStatus,
+  findByTopicIdAndType,
+  findOrCreate,
+  findById,
+  updateNewId,
 };

--- a/app/services/dynamodb.js
+++ b/app/services/dynamodb.js
@@ -123,7 +123,7 @@ const findById = (id) => {
  * @param {Number} id to find the element
  * @returns {Object} promise from the find
  */
-const findPayloadById = (id) =>
+const findPayloadById = id =>
   new Promise((resolve) => {
     findById(id).then((item) => {
       if (item.Item) {

--- a/app/services/dynamodb.js
+++ b/app/services/dynamodb.js
@@ -11,13 +11,14 @@ const updateItem = Promise.promisify(dynamodb.updateItem.bind(dynamodb));
 /**
  * Save record in the dynamoddb.
  *
+ * @param {String} id unique id to identify this object
  * @param {Object} payload object to save in the dynamodb
  * @returns {Object} promise from save
  */
-const save = payload =>
+const save = (id, payload) =>
   putItem({
     Item: {
-      Id: { S: payload.id.toString() },
+      Id: { S: id.toString() },
       Payload: { S: JSON.stringify(payload) },
       Status: { S: DISCOURSE_WEBHOOK_STATUS.PENDING },
     },

--- a/app/services/dynamodb.js
+++ b/app/services/dynamodb.js
@@ -100,7 +100,7 @@ const findByTopicIdAndType = (topicId, type) => {
 };
 
 /**
- * Find elements in dynamodb by id.
+ * Find element in dynamodb by id.  Returns the raw dynamo data.
  *
  * @param {Number} id to find the element
  * @returns {Object} promise from the find
@@ -114,9 +114,18 @@ const findById = (id) => {
     },
     TableName: dynamodbTablename,
   };
+  return getItem(payload);
+};
 
-  return new Promise((resolve) => {
-    getItem(payload).then((item) => {
+/**
+ * Find element in dynamodb by id.  Then will parse the payload and return the object.
+ *
+ * @param {Number} id to find the element
+ * @returns {Object} promise from the find
+ */
+const findPayloadById = (id) =>
+  new Promise((resolve) => {
+    findById(id).then((item) => {
       if (item.Item) {
         try {
           const existing = JSON.parse(item.Item.Payload.S);
@@ -130,7 +139,6 @@ const findById = (id) => {
       resolve(null);
     });
   });
-};
 
 /**
  * Find or create the new element
@@ -143,7 +151,7 @@ const findById = (id) => {
  */
 const findOrCreate = (id, topicId, type, payload) =>
   new Promise((resolve, reject) => {
-    findById(id).then((item) => {
+    findPayloadById(id).then((item) => {
       if (item) {
         resolve(item);
       } else {
@@ -161,6 +169,7 @@ module.exports = {
   updateStatus,
   findByTopicIdAndType,
   findOrCreate,
+  findPayloadById,
   findById,
   updateNewId,
 };

--- a/app/services/helper.js
+++ b/app/services/helper.js
@@ -17,6 +17,29 @@ const { REFERENCE_LOOKUPS } = require('../constants');
  */
 module.exports = (logger, db) => {
   /**
+   * Lookup topic from previous service
+   * @param  {Number} topicId the id of the topic we want
+   * @return {Promise} promise
+   */
+  function lookupTopic(topicId) {
+    logger.debug(`${config.get('topicServiceUrl')}/`);
+    logger.debug(`Bearer ${config.get('TC_ADMIN_TOKEN')}`);
+    return axios.get(`${config.get('topicServiceUrl')}/${topicId}`, {
+      headers: {
+        Authorization: `Bearer ${config.get('TC_ADMIN_TOKEN')}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+    .then((response) => {
+      const data = _.get(response, 'data.result.content', null);
+      if (!data) { throw new Error('Response does not have result.content'); }
+      logger.debug('TopicHandle response', data);
+      return data;
+    });
+  }
+
+  /**
    * Lookup user handles from emails
    * @param  {Array} userEmails user emails
    * @return {Promise} promise
@@ -257,5 +280,6 @@ module.exports = (logger, db) => {
     mentionUserIdToHandle,
     isAdmin,
     s3KeyFromUrl,
+    lookupTopic,
   };
 };

--- a/app/services/helper.js
+++ b/app/services/helper.js
@@ -1,5 +1,3 @@
-
-
 const _ = require('lodash');
 const config = require('config');
 const axios = require('axios');
@@ -17,14 +15,15 @@ const { REFERENCE_LOOKUPS } = require('../constants');
  */
 module.exports = (logger, db) => {
   /**
-   * Lookup topic from previous service
+   * Lookup topic from previous service.
    * @param  {Number} topicId the id of the topic we want
    * @return {Promise} promise
    */
   function lookupTopic(topicId) {
-    logger.debug(`${config.get('topicServiceUrl')}/`);
-    logger.debug(`Bearer ${config.get('TC_ADMIN_TOKEN')}`);
-    return axios.get(`${config.get('topicServiceUrl')}/${topicId}`, {
+    const url = `${config.get('topicServiceUrl')}/${topicId}`;
+    logger.debug(`Helper.lookupTopic for topicId: ${topicId} against ${url}`);
+
+    return axios.get(url, {
       headers: {
         Authorization: `Bearer ${config.get('TC_ADMIN_TOKEN')}`,
         Accept: 'application/json',
@@ -34,7 +33,7 @@ module.exports = (logger, db) => {
     .then((response) => {
       const data = _.get(response, 'data.result.content', null);
       if (!data) { throw new Error('Response does not have result.content'); }
-      logger.debug('TopicHandle response', data);
+      logger.debug('Helper.lookupTopic response', data);
       return data;
     });
   }

--- a/app/tests/discourseNewPostWebhook.json
+++ b/app/tests/discourseNewPostWebhook.json
@@ -1,0 +1,75 @@
+{
+  "post": {
+    "id": 17,
+    "name": null,
+    "username": "JonKeam",
+    "avatar_template": "/user_avatar/discourse.keam.co/jonkeam/{size}/3_1.png",
+    "created_at": "2018-04-04T02:16:12.586Z",
+    "cooked": "<p>Hi!</p>",
+    "post_number": 1,
+    "post_type": 1,
+    "updated_at": "2018-04-04T02:16:12.586Z",
+    "reply_count": 0,
+    "reply_to_post_number": null,
+    "quote_count": 0,
+    "avg_time": null,
+    "incoming_link_count": 0,
+    "reads": 1,
+    "score": 0,
+    "yours": false,
+    "topic_id": 14,
+    "topic_slug": "new-topic",
+    "topic_title": "New Topic",
+    "display_username": null,
+    "primary_group_name": null,
+    "primary_group_flair_url": null,
+    "primary_group_flair_bg_color": null,
+    "primary_group_flair_color": null,
+    "version": 1,
+    "user_title": null,
+    "actions_summary": [
+      {
+        "id": 2,
+        "can_act": true
+      },
+      {
+        "id": 5,
+        "hidden": true,
+        "can_act": true
+      },
+      {
+        "id": 3,
+        "can_act": true
+      },
+      {
+        "id": 4,
+        "can_act": true
+      },
+      {
+        "id": 8,
+        "can_act": true
+      },
+      {
+        "id": 6,
+        "can_act": true
+      },
+      {
+        "id": 7,
+        "can_act": true
+      }
+    ],
+    "moderator": false,
+    "admin": true,
+    "staff": true,
+    "user_id": 1,
+    "hidden": false,
+    "hidden_reason_id": null,
+    "trust_level": 0,
+    "deleted_at": null,
+    "user_deleted": false,
+    "edit_reason": null,
+    "can_view_edit_history": true,
+    "wiki": false,
+    "topic_posts_count": 1
+  }
+}

--- a/app/tests/discourseNewTopicWebhook.json
+++ b/app/tests/discourseNewTopicWebhook.json
@@ -1,0 +1,141 @@
+{
+  "topic": {
+    "suggested_topics": [
+      {
+        "id": 8,
+        "title": "Welcome to Discourse",
+        "fancy_title": "Welcome to Discourse",
+        "slug": "welcome-to-discourse",
+        "posts_count": 1,
+        "reply_count": 0,
+        "highest_post_number": 1,
+        "image_url": "//discourse.keam.co/images/welcome/discourse-edit-post-animated.gif",
+        "created_at": "2018-04-03T05:10:14.389Z",
+        "last_posted_at": "2018-04-03T05:10:14.457Z",
+        "bumped": true,
+        "bumped_at": "2018-04-03T06:03:21.805Z",
+        "unseen": false,
+        "last_read_post_number": 1,
+        "unread": 0,
+        "new_posts": 0,
+        "pinned": true,
+        "unpinned": null,
+        "excerpt": "You can talk about anything. \nThe first paragraph of this pinned topic will be visible as a welcome message to all new visitors on your homepage. It’s important! \nEdit this into a brief description of your community: \n\nW&hellip;",
+        "visible": true,
+        "closed": false,
+        "archived": false,
+        "notification_level": 3,
+        "bookmarked": false,
+        "liked": false,
+        "archetype": "regular",
+        "like_count": 0,
+        "views": 0,
+        "category_id": 1,
+        "featured_link": null,
+        "posters": [
+          {
+            "extras": "latest single",
+            "description": "Original Poster, Most Recent Poster",
+            "user": {
+              "id": -1,
+              "username": "system",
+              "avatar_template": "/user_avatar/discourse.keam.co/system/{size}/2_1.png"
+            }
+          }
+        ]
+      }
+    ],
+    "id": 15,
+    "title": "New Topic",
+    "fancy_title": "New Topic",
+    "posts_count": 1,
+    "created_at": "2018-04-04T02:18:25.246Z",
+    "views": 0,
+    "reply_count": 0,
+    "like_count": 0,
+    "last_posted_at": "2018-04-04T02:18:25.588Z",
+    "visible": true,
+    "closed": false,
+    "archived": false,
+    "has_summary": false,
+    "archetype": "regular",
+    "slug": "new-topic",
+    "category_id": 1,
+    "word_count": 1,
+    "deleted_at": null,
+    "pending_posts_count": 0,
+    "user_id": 1,
+    "pm_with_non_human_user": false,
+    "featured_link": null,
+    "pinned_globally": false,
+    "pinned_at": null,
+    "pinned_until": null,
+    "unpinned": null,
+    "pinned": false,
+    "details": {
+      "created_by": {
+        "id": 1,
+        "username": "JonKeam",
+        "avatar_template": "/user_avatar/discourse.keam.co/jonkeam/{size}/3_1.png"
+      },
+      "last_poster": {
+        "id": 1,
+        "username": "JonKeam",
+        "avatar_template": "/user_avatar/discourse.keam.co/jonkeam/{size}/3_1.png"
+      },
+      "participants": [
+        {
+          "id": 1,
+          "username": "JonKeam",
+          "avatar_template": "/user_avatar/discourse.keam.co/jonkeam/{size}/3_1.png",
+          "post_count": 1,
+          "primary_group_name": null,
+          "primary_group_flair_url": null,
+          "primary_group_flair_color": null,
+          "primary_group_flair_bg_color": null
+        }
+      ],
+      "notification_level": 1,
+      "can_move_posts": true,
+      "can_edit": true,
+      "can_delete": true,
+      "can_remove_allowed_users": true,
+      "can_remove_self_id": -1,
+      "can_invite_to": true,
+      "can_invite_via_email": true,
+      "can_create_post": true,
+      "can_reply_as_new_topic": true,
+      "can_flag_topic": true,
+      "can_convert_topic": true
+    },
+    "current_post_number": 1,
+    "highest_post_number": 1,
+    "deleted_by": null,
+    "has_deleted": false,
+    "actions_summary": [
+      {
+        "id": 4,
+        "count": 0,
+        "hidden": false,
+        "can_act": true
+      },
+      {
+        "id": 8,
+        "count": 0,
+        "hidden": false,
+        "can_act": true
+      },
+      {
+        "id": 7,
+        "count": 0,
+        "hidden": false,
+        "can_act": true
+      }
+    ],
+    "chunk_size": 20,
+    "bookmarked": null,
+    "topic_timer": null,
+    "private_topic_timer": null,
+    "participant_count": 1
+  }
+}

--- a/app/tests/discourseReferenceLookup.json
+++ b/app/tests/discourseReferenceLookup.json
@@ -1,41 +1,43 @@
 {
   "id": "8daa1a03-5037-4c64-abae-49f0d3312423",
   "version": "v4",
-  "result": {
-    "success": true,
-    "status": 200,
-    "content": {
-      "id": 1,
-      "dbId": 92,
-      "reference": "project",
-      "referenceId": "referenceId",
-      "tag": null,
-      "date": null,
-      "updatedDate": null,
-      "lastActivityAt": null,
-      "title": "92 created",
-      "userId": null,
-      "totalPosts": 1,
-      "retrievedPosts": 1,
-      "postIds": [
-        12
-      ],
-      "posts": [
-        {
-          "id": 1,
-          "date": null,
-          "updatedDate": null,
-          "userId": 0,
-          "read": false,
-          "body": "hi!",
-          "rawContent": "hi!",
-          "type": "post"
-        }
-      ],
-      "read": false
-    },
-    "metadata": {
-      "totalCount": 1
+  "data": {
+    "result": {
+      "success": true,
+      "status": 200,
+      "content": {
+        "id": 1,
+        "dbId": 92,
+        "reference": "project",
+        "referenceId": "referenceId",
+        "tag": null,
+        "date": null,
+        "updatedDate": null,
+        "lastActivityAt": null,
+        "title": "92 created",
+        "userId": null,
+        "totalPosts": 1,
+        "retrievedPosts": 1,
+        "postIds": [
+          12
+        ],
+        "posts": [
+          {
+            "id": 1,
+            "date": null,
+            "updatedDate": null,
+            "userId": 0,
+            "read": false,
+            "body": "hi!",
+            "rawContent": "hi!",
+            "type": "post"
+          }
+        ],
+        "read": false
+      },
+      "metadata": {
+        "totalCount": 1
+      }
     }
   }
 }

--- a/app/tests/discourseReferenceLookup.json
+++ b/app/tests/discourseReferenceLookup.json
@@ -1,0 +1,41 @@
+{
+  "id": "8daa1a03-5037-4c64-abae-49f0d3312423",
+  "version": "v4",
+  "result": {
+    "success": true,
+    "status": 200,
+    "content": {
+      "id": 1,
+      "dbId": 92,
+      "reference": "project",
+      "referenceId": "referenceId",
+      "tag": null,
+      "date": null,
+      "updatedDate": null,
+      "lastActivityAt": null,
+      "title": "92 created",
+      "userId": null,
+      "totalPosts": 1,
+      "retrievedPosts": 1,
+      "postIds": [
+        12
+      ],
+      "posts": [
+        {
+          "id": 1,
+          "date": null,
+          "updatedDate": null,
+          "userId": 0,
+          "read": false,
+          "body": "hi!",
+          "rawContent": "hi!",
+          "type": "post"
+        }
+      ],
+      "read": false
+    },
+    "metadata": {
+      "totalCount": 1
+    }
+  }
+}

--- a/app/tests/index.js
+++ b/app/tests/index.js
@@ -105,9 +105,23 @@ function prepareDB(done) {
     });
 }
 
+function findLast(model) {
+  return new Promise((resolve, reject) => {
+    model.findAll({
+      limit: 1,
+      order: [['createdAt', 'DESC']],
+    }).then((entries) => {
+      resolve(entries[0]);
+    }).catch((e) => {
+      reject(e);
+    });
+  });
+}
+
 module.exports = {
   prepareDB,
   clearDB,
   jwts,
   getDecodedToken,
+  findLast,
 };

--- a/local/README.md
+++ b/local/README.md
@@ -68,8 +68,8 @@ Note that all these properties have their corresponding environment variables th
   - secretAccessKey - AWS_SECRET_ACCESS_KEY
  - S3 - configuration related to S3
   - bucket - AWS_S3_BUCKET
- - dynamo - dynamodb config
-  - tablename - the dynamodb tablename to use.  must have a key column named `Id`
+ - dynamodb - dynamodb config
+  - discourseWebhookLogsTable - log table for discourse webhooks
 
 # Local Setup
 
@@ -182,7 +182,7 @@ Next, set the `Payload URL` to match the url of this deployed service.
 
 From there, set the `Secret` field to match the `discourseWebhookSecret` config in `default.json`.  This is the shared secret that will allow the two systems to communicate.
 
-The next step is to turn on the specific webhooks that we want.  In this case, `Post Event` should be sufficient.
+The next step is to turn on the specific webhooks that we want.  In this case, `Post Event` and `Topic Event` should be sufficient.
 
 Lastly, check the `Active` checkbox and then click `Save`.
 
@@ -241,6 +241,12 @@ We use sequelize to create and manage the database schema, to create the schema 
 ```shell
 NODE_ENV=development sequelize db:migrate
 NODE_ENV=test sequelize db:migrate
+```
+
+We will also need to create the dynamodb log table for the discourse webhooks.  To create this table, make sure you are at the project root and run:
+
+```shell
+node ./scripts/createDiscourseWebhookLogTable.js
 ```
 
 ## Running the Service

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tc-core-library-js": "git+https://github.com/appirio-tech/tc-core-library-js.git#v2.1"
   },
   "devDependencies": {
+    "aws-sdk-mock": "^1.7.0",
     "babel-cli": "^6.24.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",

--- a/scripts/createDiscourseWebhookLogTable.js
+++ b/scripts/createDiscourseWebhookLogTable.js
@@ -1,0 +1,53 @@
+const aws = require('aws-sdk');
+const config = require('config');
+const Promise = require('bluebird');
+
+const dynamodb = new aws.DynamoDB(config.get('aws.config'));
+const createTable = Promise.promisify(dynamodb.createTable.bind(dynamodb));
+
+const TableName = config.get('aws.dynamodb.discourseWebhookLogsTable');
+
+const params = {
+  AttributeDefinitions: [{
+    AttributeName: 'Id',
+    AttributeType: 'S'
+  },{
+    AttributeName: 'TopicId',
+    AttributeType: 'S'
+  }, {
+    AttributeName: 'Type',
+    AttributeType: 'S'
+  }],
+  KeySchema: [{
+    AttributeName: 'Id',
+    KeyType: 'HASH'
+  }],
+  GlobalSecondaryIndexes: [{
+    IndexName: 'TopicId-Type-index',
+    KeySchema: [{
+      AttributeName: 'TopicId',
+      KeyType: 'HASH'
+    }, {
+      AttributeName: 'Type',
+      KeyType: 'RANGE'
+    }],
+    Projection: {
+      ProjectionType: 'ALL'
+    },
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 5,
+      WriteCapacityUnits: 5
+    }
+  }],
+  ProvisionedThroughput: {
+    ReadCapacityUnits: 5,
+    WriteCapacityUnits: 5
+  },
+  TableName
+};
+
+createTable(params).then((data) => {
+  console.log('Created table. Table description JSON:', JSON.stringify(data, null, 2));
+}).catch((err) => {
+  console.error('Unable to create table. Error JSON:', JSON.stringify(err, null, 2));
+});


### PR DESCRIPTION
Work included:

1.  Handling of new Discourse Topics sent via webhook
2.  Rework Discourse Webhook to be able to keep the associations between Topics and Posts in the new Postgres DB despite us regenerating PKs when these new objects are created
3.  Test for Discourse Webhook functionality - Topic Handling
4.  Test for Discourse Webhook functionality - Post Handling
5.  Test for Sendgrid Webhook
6.  Added script to generate DynamoDB table

Notes:
As we discussed via email, this uses TC_ADMIN_TOKEN so make sure that is set.

Lastly, if you prefer I squash all these commits, let me know and I can do that.